### PR TITLE
Added apparently missing LIST_OF_SYSTEM_CONTROLS

### DIFF
--- a/smartapps/echo/AWS_Files/MainCustomSlots
+++ b/smartapps/echo/AWS_Files/MainCustomSlots
@@ -252,6 +252,18 @@ which
 who
 
 
+LIST_OF_SYSTEM_CONTROLS
+
+Away
+Away Mode
+Day
+Day Mode
+Evening
+Evening Mode
+Late Night
+Late Night Mode
+
+
 LIST_OF_TYPES
 
 mode


### PR DESCRIPTION
I may very well have missed something but in following the installation steps, i did not find the LIST_OF_SYSTEM_CONTROLS in the MainCustomSlots file.

Really impressed with this project.  